### PR TITLE
Fix validation command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ This should create a directory called `signatures` with the polynomial encodings
 You can then run validation with:
 
 ```bash
-python vllm_validate_poly.py --decode_model_name meta-llama/Llama-3.1-8B-Instruct --validate_model_name meta-llama/Llama-3.1-8B-Instruct --tp 1 --n_samples 4 --save_dir just4 --max_decode_tokens 512 --dataset_name stingning/ultrachat --dtype bfloat16 --attn flash
+python vllm_validate_poly.py --decode_model_name meta-llama/Llama-3.1-8B-Instruct --validate_model_name meta-llama/Llama-3.1-8B-Instruct --tp 1 --save_dir signatures --max_decode_tokens 512 --dtype bfloat16 --attn flash
 ```
 
 If the verification passes, you should see:

--- a/vllm_generate_poly.py
+++ b/vllm_generate_poly.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 def parse_args():
     parser = argparse.ArgumentParser(description="Run activation saving and inference generation with a language model.")
-    
+
     parser.add_argument("--model_name", type=str, default="meta-llama/Llama-3.1-8B-Instruct", help="Name of the model to use.")
     parser.add_argument("--tp", type=int, default=1, help="Tensor parallel size.")
     parser.add_argument("--n_samples", type=int, default=4, help="Number of samples to generate.")
@@ -18,7 +18,8 @@ def parse_args():
     parser.add_argument("--dataset_name", type=str, default="stingning/ultrachat", help="Dataset to load.")
     parser.add_argument("--system_prompt", type=str, default="None", help="System prompt to prepend to each input.")
     parser.add_argument("--dtype", type=str, default="bfloat16")
-    
+    parser.add_argument("--enable_toploc", type=bool, default=True)
+
     return parser.parse_args()
 
 K = 128
@@ -40,10 +41,14 @@ def build_activation_commit(activations: list[torch.Tensor], decode_batching_siz
         topk_values = flat_view[topk_indices]
         commit = ProofPoly.from_points(topk_indices, topk_values).to_bytes()
         commits.append(commit)
-        
+
     return commits
 
 def main(args):
+    # Before running inference
+    torch.cuda.reset_peak_memory_stats()
+    torch.cuda.empty_cache()
+
     if args.system_prompt != "None":
         raise NotImplementedError("System prompts are not yet supported.")
 
@@ -59,8 +64,15 @@ def main(args):
 
     saved_activations = []
     def activation_saving_hook(module, input, output):
+        # if len(saved_activations) == 0:
+            # print("output.shape is ", len(output))
+            # print("output[0].shape is ", output[0].shape)
+            # print("output[0] is ", output[0])
+            # print("output[1].shape is ", output[1].shape)
+            # print("output[1] is ", output[1])
         saved_activations.append(output[0].detach().clone().cpu())
-    saved_activations_handle = model.model.norm.register_forward_hook(activation_saving_hook)
+    if args.enable_toploc:
+        saved_activations_handle = model.model.norm.register_forward_hook(activation_saving_hook)
 
     ds = load_dataset(args.dataset_name, split="train")
     prompts = [i['data'][0] for _, i in zip(range(args.n_samples), ds)]
@@ -72,25 +84,40 @@ def main(args):
     outputs = []
     for prompt in tqdm(prompts):
         output = llm.generate([prompt], sampling_params)
+        # print("length of output is ", len(output))
         input_ids = output[0].prompt_token_ids
+        # print("length of input_ids is ", len(input_ids))
+        # print("text of input is ", output[0].prompt)
         output_ids = output[0].outputs[0].token_ids
+        # print("length of output_ids is ", len(output_ids))
+        # print("text of output is ", output[0].outputs[0].text)
         output = torch.tensor([[*input_ids, *output_ids]])
 
         outputs.append(output)
 
-        act_commit = build_activation_commit(saved_activations, args.decode_batching_size)
-        saved_commits.append(act_commit)
-        saved_activations = []
+        if args.enable_toploc:
+            act_commit = build_activation_commit(saved_activations, args.decode_batching_size)
+            # print("the length of saved_activations is ", len(saved_activations))
+            # for act in saved_activations:
+            #   print("act shape is ", act.shape)
+            saved_commits.append(act_commit)
+            saved_activations = []
 
     torch.save(outputs, output_save_path)
     print(f"Saved outputs to {output_save_path}")
 
-    savepath = save_dir / f"poly_{args.model_name.replace('/', '--')}_128.bin"
-    with open(savepath, "wb") as f:
-        for commit in saved_commits:
-            for c in commit:
-                f.write(c)
-    print(f"Saved to {savepath}")
+    if args.enable_toploc:
+        savepath = save_dir / f"poly_{args.model_name.replace('/', '--')}_128.bin"
+        with open(savepath, "wb") as f:
+            for commit in saved_commits:
+                for c in commit:
+                    f.write(c)
+        print(f"Saved to {savepath}")
+
+    # After inference
+    peak_memory_bytes = torch.cuda.max_memory_allocated()
+    peak_memory_gb = peak_memory_bytes / (1024 ** 3)
+    print(f"Peak GPU memory usage: {peak_memory_gb:.2f} GB")
 
 if __name__ == "__main__":
     args = parse_args()


### PR DESCRIPTION
I encountered the following error when running the validation command:
```
usage: vllm_validate_poly.py [-h] --save_dir SAVE_DIR --decode_model_name
                             DECODE_MODEL_NAME --validate_model_name
                             VALIDATE_MODEL_NAME [--tp TP]
                             [--max_decode_tokens MAX_DECODE_TOKENS]
                             [--decode_batching_size DECODE_BATCHING_SIZE]
                             [--dtype DTYPE] [--attn ATTN]
                             [--scale_decode_mantissa SCALE_DECODE_MANTISSA]
vllm_validate_poly.py: error: unrecognized arguments: --n_samples 4 --dataset_name stingning/ultrachat
```

It looks like `--n_samples` and `--dataset_name` are not supported arguments in `vllm_validate_poly.py`. Also, the `--save_dir` argument should be set to `signatures` where we generated results in the previous step.